### PR TITLE
sg2042: fix KUnit Error: unrecognized opcode cbo.clean (a0)

### DIFF
--- a/arch/riscv/include/asm/errata_list.h
+++ b/arch/riscv/include/asm/errata_list.h
@@ -166,11 +166,11 @@ asm volatile(ALTERNATIVE_2(						\
 	"mv a0, %1\n\t"							\
 	"j 2f\n\t"							\
 	"3:\n\t"							\
-	"cbo." __stringify(_op) " (a0)\n\t"				\
+	CBO_##_op(a0)							\
 	"add a0, a0, %0\n\t"						\
 	"2:\n\t"							\
 	"bltu a0, %2, 3b\n\t"						\
-	"nop", 0, CPUFEATURE_ZICBOM, CONFIG_RISCV_ISA_ZICBOM,		\
+	"nop", 0, RISCV_ISA_EXT_ZICBOM, CONFIG_RISCV_ISA_ZICBOM,		\
 	"mv a0, %3\n\t"							\
 	"j 2f\n\t"							\
 	"3:\n\t"							\


### PR DESCRIPTION
**KUnit test error:**
  arch/riscv/mm/dma-noncoherent.c:54:
    Error: unrecognized opcode cbo.clean (a0)', extension zicbom' required

**Related commit:** 
   1. [RISC-V: replace cbom instructions with an insn-def](https://github.com/RVCK-Project/rvck-olk/commit/dd23e95)
   2. [riscv: cpufeature: extend riscv_cpufeature_patch_func to all ISA extensions](https://github.com/RVCK-Project/rvck-olk/commit/4bf8860)

**Related issue:** <https://github.com/RVCK-Project/rvck/issues/16>.