### PR TITLE
sg2042: riscv: dts: Add cache info for SG2042

### DIFF
--- a/arch/riscv/boot/dts/sophgo/mango-cpus-socket0.dtsi
+++ b/arch/riscv/boot/dts/sophgo/mango-cpus-socket0.dtsi
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2022 Sophgo Technology Inc. All rights reserved.
+ */
+
 / {
 	cpus {
 		#address-cells = <1>;
@@ -249,900 +254,1836 @@
 		};
 
 		cpu0: cpu@0 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <0>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache0>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu0_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu1: cpu@1 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <1>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache0>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu1_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu2: cpu@2 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <2>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache0>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu2_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu3: cpu@3 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <3>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache0>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu3_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu4: cpu@4 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <4>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache1>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu4_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu5: cpu@5 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <5>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache1>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu5_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu6: cpu@6 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <6>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache1>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu6_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu7: cpu@7 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <7>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache1>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu7_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu8: cpu@8 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <8>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache4>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu8_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu9: cpu@9 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <9>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache4>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu9_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu10: cpu@10 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <10>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache4>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu10_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu11: cpu@11 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <11>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache4>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu11_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu12: cpu@12 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <12>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache5>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu12_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu13: cpu@13 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <13>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache5>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu13_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu14: cpu@14 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <14>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache5>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu14_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu15: cpu@15 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <15>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache5>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu15_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu16: cpu@16 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <16>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache2>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu16_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu17: cpu@17 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <17>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache2>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu17_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu18: cpu@18 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <18>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache2>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu18_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu19: cpu@19 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <19>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache2>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu19_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu20: cpu@20 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <20>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache3>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu20_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu21: cpu@21 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <21>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache3>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu21_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu22: cpu@22 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <22>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache3>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu22_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu23: cpu@23 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
-			reg = <23>;
-			status = "okay";
-			compatible = "riscv";
 			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
+			reg = <23>;
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache3>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <0>;
+
 			cpu23_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu24: cpu@24 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <24>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache6>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu24_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu25: cpu@25 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <25>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache6>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu25_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu26: cpu@26 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <26>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache6>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu26_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu27: cpu@27 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <27>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache6>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu27_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu28: cpu@28 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <28>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache7>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu28_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu29: cpu@29 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <29>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache7>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu29_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu30: cpu@30 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <30>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache7>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu30_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu31: cpu@31 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
-			reg = <31>;
-			status = "okay";
-			compatible = "riscv";
 			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
+			reg = <31>;
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache7>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <1>;
+
 			cpu31_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu32: cpu@32 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <32>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache8>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu32_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu33: cpu@33 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <33>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache8>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu33_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu34: cpu@34 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <34>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache8>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu34_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu35: cpu@35 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <35>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache8>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu35_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu36: cpu@36 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <36>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache9>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu36_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu37: cpu@37 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <37>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache9>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu37_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu38: cpu@38 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <38>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache9>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu38_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu39: cpu@39 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <39>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache9>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu39_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu40: cpu@40 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <40>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache12>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu40_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu41: cpu@41 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <41>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache12>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu41_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu42: cpu@42 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <42>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache12>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu42_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu43: cpu@43 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <43>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache12>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu43_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu44: cpu@44 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <44>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache13>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu44_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu45: cpu@45 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <45>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache13>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu45_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu46: cpu@46 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <46>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache13>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu46_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu47: cpu@47 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <47>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache13>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu47_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu48: cpu@48 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <48>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache10>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu48_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu49: cpu@49 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <49>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache10>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu49_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu50: cpu@50 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <50>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache10>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu50_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu51: cpu@51 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <51>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache10>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu51_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu52: cpu@52 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <52>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache11>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu52_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu53: cpu@53 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <53>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache11>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu53_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu54: cpu@54 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <54>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache11>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu54_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu55: cpu@55 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
-			reg = <55>;
-			status = "okay";
-			compatible = "riscv";
 			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
+			reg = <55>;
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache11>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <2>;
+
 			cpu55_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu56: cpu@56 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <56>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache14>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu56_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu57: cpu@57 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <57>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache14>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu57_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu58: cpu@58 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <58>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache14>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu58_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu59: cpu@59 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <59>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache14>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu59_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu60: cpu@60 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <60>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache15>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu60_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu61: cpu@61 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <61>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache15>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu61_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu62: cpu@62 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
-			reg = <62>;
-			status = "okay";
-			compatible = "riscv";
 			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
+			reg = <62>;
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache15>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu62_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu63: cpu@63 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
-			reg = <63>;
-			status = "okay";
-			compatible = "riscv";
 			riscv,isa = "rv64imafdc";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
+			reg = <63>;
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache15>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <3>;
+
 			cpu63_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
+		};
+
+		l2_cache0: cache-controller-0 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l2_cache1: cache-controller-1 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l2_cache2: cache-controller-2 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l2_cache3: cache-controller-3 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l2_cache4: cache-controller-4 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l2_cache5: cache-controller-5 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l2_cache6: cache-controller-6 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l2_cache7: cache-controller-7 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l2_cache8: cache-controller-8 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l2_cache9: cache-controller-9 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l2_cache10: cache-controller-10 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l2_cache11: cache-controller-11 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l2_cache12: cache-controller-12 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l2_cache13: cache-controller-13 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l2_cache14: cache-controller-14 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l2_cache15: cache-controller-15 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache0>;
+		};
+
+		l3_cache0: cache-controller-130 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <3>;
+			cache-size = <67108864>;
+			cache-sets = <4096>;
+			cache-unified;
 		};
 	};
 };

--- a/arch/riscv/boot/dts/sophgo/mango-cpus-socket1.dtsi
+++ b/arch/riscv/boot/dts/sophgo/mango-cpus-socket1.dtsi
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2022 Sophgo Technology Inc. All rights reserved.
+ */
+
 / {
 	cpus {
 		#address-cells = <1>;
@@ -248,902 +253,1838 @@
 			};
 		};
 
-
 		cpu64: cpu@64 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <64>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache16>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu64_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu65: cpu@65 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <65>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache16>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu65_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu66: cpu@66 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <66>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache16>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu66_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu67: cpu@67 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <67>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache16>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu67_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu68: cpu@68 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <68>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache17>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu68_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu69: cpu@69 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <69>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache17>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu69_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu70: cpu@70 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <70>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache17>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu70_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu71: cpu@71 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <71>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache17>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu71_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu72: cpu@72 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <72>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache20>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu72_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu73: cpu@73 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <73>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache20>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu73_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu74: cpu@74 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <74>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache20>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu74_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu75: cpu@75 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <75>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache20>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu75_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu76: cpu@76 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <76>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache21>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu76_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu77: cpu@77 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <77>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache21>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu77_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu78: cpu@78 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <78>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache21>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu78_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu79: cpu@79 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <79>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache21>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu79_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu80: cpu@80 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <80>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache18>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu80_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu81: cpu@81 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <81>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache18>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu81_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu82: cpu@82 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <82>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache18>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu82_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu83: cpu@83 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <83>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache18>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu83_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu84: cpu@84 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <84>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache19>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu84_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu85: cpu@85 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <85>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache19>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu85_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu86: cpu@86 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <86>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache19>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu86_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu87: cpu@87 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <87>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache19>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <4>;
+
 			cpu87_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu88: cpu@88 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <88>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache22>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu88_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu89: cpu@89 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <89>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache22>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu89_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu90: cpu@90 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <90>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache22>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu90_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu91: cpu@91 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <91>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache22>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu91_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu92: cpu@92 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <92>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache23>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu92_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu93: cpu@93 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <93>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache23>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu93_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu94: cpu@94 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <94>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache23>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu94_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu95: cpu@95 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <95>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache23>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <5>;
+
 			cpu95_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu96: cpu@96 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <96>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache24>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu96_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu97: cpu@97 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <97>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache24>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu97_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu98: cpu@98 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <98>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache24>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu98_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu99: cpu@99 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <99>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache24>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu99_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu100: cpu@100 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <100>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache25>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu100_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu101: cpu@101 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <101>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache25>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu101_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu102: cpu@102 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <102>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache25>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu102_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu103: cpu@103 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <103>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache25>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu103_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu104: cpu@104 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <104>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache28>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu104_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu105: cpu@105 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <105>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache28>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu105_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu106: cpu@106 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <106>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache28>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu106_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu107: cpu@107 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <107>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache28>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu107_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu108: cpu@108 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <108>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache29>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu108_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu109: cpu@109 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <109>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache29>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu109_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu110: cpu@110 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <110>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache29>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu110_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu111: cpu@111 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <111>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache29>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu111_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu112: cpu@112 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <112>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache26>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu112_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu113: cpu@113 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <113>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache26>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu113_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu114: cpu@114 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <114>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache26>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu114_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu115: cpu@115 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <115>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache26>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu115_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu116: cpu@116 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <116>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache27>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu116_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu117: cpu@117 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <117>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache27>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu117_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu118: cpu@118 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <118>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache27>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu118_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu119: cpu@119 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <119>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache27>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <6>;
+
 			cpu119_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu120: cpu@120 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <120>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache30>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu120_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu121: cpu@121 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <121>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache30>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu121_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu122: cpu@122 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <122>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache30>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu122_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu123: cpu@123 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <123>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache30>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu123_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu124: cpu@124 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <124>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache31>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu124_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu125: cpu@125 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <125>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache31>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu125_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu126: cpu@126 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <126>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache31>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu126_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
 		cpu127: cpu@127 {
+			compatible = "thead,c920", "riscv";
 			device_type = "cpu";
+			riscv,isa = "rv64imafdcv";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v",
+					       "zicntr", "zicsr", "zifencei",
+					       "zihpm";
 			reg = <127>;
-			status = "okay";
-			compatible = "riscv";
-			riscv,isa = "rv64imafdc";
+			i-cache-block-size = <64>;
+			i-cache-size = <65536>;
+			i-cache-sets = <512>;
+			d-cache-block-size = <64>;
+			d-cache-size = <65536>;
+			d-cache-sets = <512>;
+			next-level-cache = <&l2_cache31>;
 			mmu-type = "riscv,sv39";
 			numa-node-id = <7>;
+
 			cpu127_intc: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
+				#interrupt-cells = <1>;
 			};
 		};
+
+		l2_cache16: cache-controller-16 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l2_cache17: cache-controller-17 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l2_cache18: cache-controller-18 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l2_cache19: cache-controller-19 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l2_cache20: cache-controller-20 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l2_cache21: cache-controller-21 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l2_cache22: cache-controller-22 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l2_cache23: cache-controller-23 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l2_cache24: cache-controller-24 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l2_cache25: cache-controller-25 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l2_cache26: cache-controller-26 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l2_cache27: cache-controller-27 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l2_cache28: cache-controller-28 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l2_cache29: cache-controller-29 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l2_cache30: cache-controller-30 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l2_cache31: cache-controller-31 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-size = <1048576>;
+			cache-sets = <1024>;
+			cache-unified;
+			next-level-cache = <&l3_cache1>;
+		};
+
+		l3_cache1: cache-controller-131 {
+			compatible = "cache";
+			cache-block-size = <64>;
+			cache-level = <3>;
+			cache-size = <67108864>;
+			cache-sets = <4096>;
+			cache-unified;
+		};
+
 	};
 };


### PR DESCRIPTION
Add cache information in the device tree so that it can be shown correctly in the /sys filesystem.

Fixes: RVCK-Project/rvck#21 