### PR TITLE
RISC-V: Enable IPI CPU Backtrace

### DIFF
--- a/arch/riscv/include/asm/irq.h
+++ b/arch/riscv/include/asm/irq.h
@@ -14,6 +14,11 @@
 
 #define INVALID_CONTEXT UINT_MAX
 
+#ifdef CONFIG_SMP
+bool arch_trigger_cpumask_backtrace(const cpumask_t *mask, int exclude_cpu);
+#define arch_trigger_cpumask_backtrace arch_trigger_cpumask_backtrace
+#endif
+
 void riscv_set_intc_hwnode_fn(struct fwnode_handle *(*fn)(void));
 
 struct fwnode_handle *riscv_get_intc_hwnode(void);

--- a/arch/riscv/kernel/smp.c
+++ b/arch/riscv/kernel/smp.c
@@ -25,6 +25,7 @@
 #include <asm/tlbflush.h>
 #include <asm/cacheflush.h>
 #include <asm/cpu_ops.h>
+#include <linux/nmi.h>
 
 enum ipi_message_type {
 	IPI_RESCHEDULE,
@@ -33,6 +34,7 @@ enum ipi_message_type {
 	IPI_CPU_CRASH_STOP,
 	IPI_IRQ_WORK,
 	IPI_TIMER,
+	IPI_CPU_BACKTRACE,
 	IPI_MAX
 };
 
@@ -136,6 +138,9 @@ static irqreturn_t handle_IPI(int irq, void *data)
 		tick_receive_broadcast();
 		break;
 #endif
+	case IPI_CPU_BACKTRACE:
+		nmi_cpu_backtrace(get_irq_regs());
+		break;
 	default:
 		pr_warn("CPU%d: unhandled IPI%d\n", smp_processor_id(), ipi);
 		break;
@@ -212,6 +217,7 @@ static const char * const ipi_names[] = {
 	[IPI_CPU_CRASH_STOP]	= "CPU stop (for crash dump) interrupts",
 	[IPI_IRQ_WORK]		= "IRQ work interrupts",
 	[IPI_TIMER]		= "Timer broadcast interrupts",
+	[IPI_CPU_BACKTRACE]     = "CPU backtrace interrupts",
 };
 
 void show_ipi_stats(struct seq_file *p, int prec)
@@ -332,3 +338,14 @@ void arch_smp_send_reschedule(int cpu)
 	send_ipi_single(cpu, IPI_RESCHEDULE);
 }
 EXPORT_SYMBOL_GPL(arch_smp_send_reschedule);
+
+static void riscv_backtrace_ipi(cpumask_t *mask)
+{
+	send_ipi_mask(mask, IPI_CPU_BACKTRACE);
+}
+
+bool arch_trigger_cpumask_backtrace(const cpumask_t *mask, int exclude_cpu)
+{
+	nmi_trigger_cpumask_backtrace(mask, exclude_cpu, riscv_backtrace_ipi);
+	return true;
+}


### PR DESCRIPTION
当前riscv版本无法像arm和x86那样在oops故障时打印所有cpu堆栈，故障发生时只能打印当前cpu堆栈回溯。
这个补丁在oops或lookup等故障排查时相当重要，在sysctl中配置了kernel.oops_all_cpu_backtrace=1，这个补丁可以让故障发生时打印出所有cpu的堆栈回溯。

类似于

[ 229.185877] Sending NMI from CPU 5 to CPUs 0-4,6-7:
[ 229.187808] NMI backtrace for cpu 7
[ 229.188979] CPU: 7 PID: 0 Comm: swapper/7 Not tainted 6.6.25 https://github.com/RVCK-Project/rvck-olk/pull/20
[ 229.190026] Hardware name: riscv-virtio,qemu (DT)
[ 229.190947] epc : arch_local_irq_enable+0xc/0x14
[ 229.191988] ra : default_idle_call+0x3a/0x42
[ 229.193013] epc : ffffffff8007dbb0 ra : ffffffff80ed8120 sp : ff2000000013bed0
[ 229.194166] gp : ffffffff8202d8a0 tp : ff60000080289900 t0 : ff200000006d35c0
[ 229.195611] t1 : ffebffff4e9ac459 t2 : ffffffff818264a8 s0 : ff2000000013bee0
[ 229.196927] s1 : ffffffff8203a1c0 a0 : 0000000000000000 a1 : 0000000000000004
[ 229.198058] a2 : 0000000000000000 a3 : 0000000000001d6c a4 : ff600002f3b34000
[ 229.199242] a5 : 4000000000000000 a6 : ffebffff4e9ac45a a7 : ff60000274d622cb
[ 229.200451] s2 : 0000000000000007 s3 : 000000000000003f s4 : 0000000000000007
[ 229.201556] s5 : ff2000000013bf40 s6 : 1fe40000000277e0 s7 : 0000000000000000
[ 229.202680] s8 : 0000000000000000 s9 : ff60000080289900 s10: 0000000000000000
[ 229.203931] s11: 0000000000000000 t3 : ffebffff4e9ac459 t4 : ffebffff4e9ac45a
[ 229.204918] t5 : ffffffff818139a0 t6 : ffffffff818139e8
[ 229.205696] status: 0000000200000120 badaddr: 0000000000000000 cause: 8000000000000009
[ 229.206833] [] arch_local_irq_enable+0xc/0x14
[ 229.208202] [] default_idle_call+0x3a/0x42
[ 229.209377] [] do_idle+0x2c4/0x322
[ 229.210422] [] cpu_startup_entry+0x36/0x38
[ 229.211533] [] smp_callin+0xa4/0xd4


fixed: <https://github.com/RVCK-Project/rvck/issues/52>