### PR TITLE
RISC-V: Select ACPI PPTT drivers

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -13,6 +13,7 @@ config 32BIT
 config RISCV
 	def_bool y
 	select ACPI_GENERIC_GSI if ACPI
+	select ACPI_PPTT if ACPI
 	select ACPI_MCFG if (ACPI && PCI)
 	select ACPI_REDUCED_HARDWARE_ONLY if ACPI
 	select ACPI_SPCR_TABLE if ACPI


### PR DESCRIPTION
cacheinfo: initialize cacheinfo's level and type from ACPI PPTT
a06bdf4d6df7cb69c86abf17f97a1d3750ba016d

cacheinfo: remove the useless input parameter (node) of ci_leaf_init()
ebccacb0b599fa788a16eff35a7de14621f56804

上述两个补丁已经合入，只需要合入下面的补丁
RISC-V: Select ACPI PPTT drivers
66381d36771e4ffedbea0dd23da17cf3d38e9aae

fixed: <https://github.com/RVCK-Project/rvck/issues/58>