### PR TITLE
Fix  th1520 cpu_pll1 already disabled warning

### DIFF
--- a/drivers/cpufreq/th1520-cpufreq.c
+++ b/drivers/cpufreq/th1520-cpufreq.c
@@ -83,19 +83,23 @@ static int _th1520_get_pllid(void)
 
 static int _th1520_switch_pllid(int pllid, int target_freq)
 {
+	int ret;
+
 	pr_debug("[%s] switch to pll[%d], freq[%u]\n", __func__, pllid, target_freq);
 	if (pllid == TH1520_CPU_PLL_IDX(1)) {
 		clk_prepare_enable(clks[TH1520_CPU_PLL1_FOUTPOSTDIV].clk);
 		clk_set_rate(clks[TH1520_CPU_PLL1_FOUTPOSTDIV].clk, target_freq * 1000);
-		clk_set_parent(clks[TH1520_C910_CCLK].clk, clks[TH1520_CPU_PLL1_FOUTPOSTDIV].clk);
+		ret = clk_set_parent(clks[TH1520_C910_CCLK].clk, clks[TH1520_CPU_PLL1_FOUTPOSTDIV].clk);
 		udelay(1);
-		clk_disable_unprepare(clks[TH1520_CPU_PLL0_FOUTPOSTDIV].clk);
+		if (ret)
+			clk_disable_unprepare(clks[TH1520_CPU_PLL0_FOUTPOSTDIV].clk);
 	} else {
 		clk_prepare_enable(clks[TH1520_CPU_PLL0_FOUTPOSTDIV].clk);
 		clk_set_rate(clks[TH1520_CPU_PLL0_FOUTPOSTDIV].clk, target_freq * 1000);
-		clk_set_parent(clks[TH1520_C910_CCLK].clk, clks[TH1520_C910_CCLK_I0].clk);
+		ret = clk_set_parent(clks[TH1520_C910_CCLK].clk, clks[TH1520_C910_CCLK_I0].clk);
 		udelay(1);
-		clk_disable_unprepare(clks[TH1520_CPU_PLL1_FOUTPOSTDIV].clk);
+		if (ret)
+			clk_disable_unprepare(clks[TH1520_CPU_PLL1_FOUTPOSTDIV].clk);
 	}
 
 	return 0;


### PR DESCRIPTION
Fix warning in _th1520_switch_pllid() during boot that cpu_pll1_foutpostdiv was already disabled. Only call clk_disable_unprepare() for TH1520_CPU_PLL0_FOUTPOSTDIV if clk_set_parent() returns non-zero value.

Tested on Lpi4a.