### PR TITLE
RISC-V: Define struct hid_bpf_ctx to fix kselftest hid-bpf compilation

### DIFF
--- a/tools/testing/selftests/hid/Makefile
+++ b/tools/testing/selftests/hid/Makefile
@@ -25,6 +25,8 @@ CXX ?= $(CROSS_COMPILE)g++
 HOSTPKG_CONFIG := pkg-config
 
 CFLAGS += -g -O0 -rdynamic -Wall -Werror -I$(OUTPUT)
+CFLAGS += -I$(OUTPUT)/tools/include
+
 LDLIBS += -lelf -lz -lrt -lpthread
 
 # Silence some warnings when compiled with clang

--- a/tools/testing/selftests/hid/Makefile
+++ b/tools/testing/selftests/hid/Makefile
@@ -24,7 +24,7 @@ CXX ?= $(CROSS_COMPILE)g++
 
 HOSTPKG_CONFIG := pkg-config
 
-CFLAGS += -g -O0 -rdynamic -Wall -Werror -I$(KHDR_INCLUDES) -I$(OUTPUT)
+CFLAGS += -g -O0 -rdynamic -Wall -Werror -I$(OUTPUT)
 LDLIBS += -lelf -lz -lrt -lpthread
 
 # Silence some warnings when compiled with clang
@@ -68,7 +68,6 @@ BPFTOOLDIR := $(TOOLSDIR)/bpf/bpftool
 SCRATCH_DIR := $(OUTPUT)/tools
 BUILD_DIR := $(SCRATCH_DIR)/build
 INCLUDE_DIR := $(SCRATCH_DIR)/include
-KHDR_INCLUDES := $(SCRATCH_DIR)/uapi/include
 BPFOBJ := $(BUILD_DIR)/libbpf/libbpf.a
 ifneq ($(CROSS_COMPILE),)
 HOST_BUILD_DIR		:= $(BUILD_DIR)/host
@@ -154,9 +153,6 @@ else
 	$(Q)cp "$(VMLINUX_H)" $@
 endif
 
-$(KHDR_INCLUDES)/linux/hid.h: $(top_srcdir)/include/uapi/linux/hid.h
-	$(MAKE) -C $(top_srcdir) INSTALL_HDR_PATH=$(SCRATCH_DIR)/uapi headers_install
-
 $(RESOLVE_BTFIDS): $(HOST_BPFOBJ) | $(HOST_BUILD_DIR)/resolve_btfids	\
 		       $(TOOLSDIR)/bpf/resolve_btfids/main.c	\
 		       $(TOOLSDIR)/lib/rbtree.c			\
@@ -234,7 +230,7 @@ $(BPF_SKELS): %.skel.h: %.bpf.o $(BPFTOOL) | $(OUTPUT)
 	$(Q)$(BPFTOOL) gen object $(<:.o=.linked1.o) $<
 	$(Q)$(BPFTOOL) gen skeleton $(<:.o=.linked1.o) name $(notdir $(<:.bpf.o=)) > $@
 
-$(OUTPUT)/%.o: %.c $(BPF_SKELS) $(KHDR_INCLUDES)/linux/hid.h
+$(OUTPUT)/%.o: %.c $(BPF_SKELS)
 	$(call msg,CC,,$@)
 	$(Q)$(CC) $(CFLAGS) -c $(filter %.c,$^) $(LDLIBS) -o $@
 

--- a/tools/testing/selftests/hid/progs/hid.c
+++ b/tools/testing/selftests/hid/progs/hid.c
@@ -1,8 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
 /* Copyright (c) 2022 Red hat */
-#include "vmlinux.h"
-#include <bpf/bpf_helpers.h>
-#include <bpf/bpf_tracing.h>
 #include "hid_bpf_helpers.h"
 
 char _license[] SEC("license") = "GPL";

--- a/tools/testing/selftests/hid/progs/hid_bpf_helpers.h
+++ b/tools/testing/selftests/hid/progs/hid_bpf_helpers.h
@@ -5,6 +5,83 @@
 #ifndef __HID_BPF_HELPERS_H
 #define __HID_BPF_HELPERS_H
 
+/* "undefine" structs and enums in vmlinux.h, because we "override" them below */
+#define hid_bpf_ctx hid_bpf_ctx___not_used
+#define hid_report_type hid_report_type___not_used
+#define hid_class_request hid_class_request___not_used
+#define hid_bpf_attach_flags hid_bpf_attach_flags___not_used
+#define HID_INPUT_REPORT         HID_INPUT_REPORT___not_used
+#define HID_OUTPUT_REPORT        HID_OUTPUT_REPORT___not_used
+#define HID_FEATURE_REPORT       HID_FEATURE_REPORT___not_used
+#define HID_REPORT_TYPES         HID_REPORT_TYPES___not_used
+#define HID_REQ_GET_REPORT       HID_REQ_GET_REPORT___not_used
+#define HID_REQ_GET_IDLE         HID_REQ_GET_IDLE___not_used
+#define HID_REQ_GET_PROTOCOL     HID_REQ_GET_PROTOCOL___not_used
+#define HID_REQ_SET_REPORT       HID_REQ_SET_REPORT___not_used
+#define HID_REQ_SET_IDLE         HID_REQ_SET_IDLE___not_used
+#define HID_REQ_SET_PROTOCOL     HID_REQ_SET_PROTOCOL___not_used
+#define HID_BPF_FLAG_NONE        HID_BPF_FLAG_NONE___not_used
+#define HID_BPF_FLAG_INSERT_HEAD HID_BPF_FLAG_INSERT_HEAD___not_used
+#define HID_BPF_FLAG_MAX         HID_BPF_FLAG_MAX___not_used
+
+#include "vmlinux.h"
+
+#undef hid_bpf_ctx
+#undef hid_report_type
+#undef hid_class_request
+#undef hid_bpf_attach_flags
+#undef HID_INPUT_REPORT
+#undef HID_OUTPUT_REPORT
+#undef HID_FEATURE_REPORT
+#undef HID_REPORT_TYPES
+#undef HID_REQ_GET_REPORT
+#undef HID_REQ_GET_IDLE
+#undef HID_REQ_GET_PROTOCOL
+#undef HID_REQ_SET_REPORT
+#undef HID_REQ_SET_IDLE
+#undef HID_REQ_SET_PROTOCOL
+#undef HID_BPF_FLAG_NONE
+#undef HID_BPF_FLAG_INSERT_HEAD
+#undef HID_BPF_FLAG_MAX
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <linux/const.h>
+
+enum hid_report_type {
+	HID_INPUT_REPORT		= 0,
+	HID_OUTPUT_REPORT		= 1,
+	HID_FEATURE_REPORT		= 2,
+
+	HID_REPORT_TYPES,
+};
+
+struct hid_bpf_ctx {
+	__u32 index;
+	const struct hid_device *hid;
+	__u32 allocated_size;
+	enum hid_report_type report_type;
+	union {
+		__s32 retval;
+		__s32 size;
+	};
+} __attribute__((preserve_access_index));
+
+enum hid_class_request {
+	HID_REQ_GET_REPORT		= 0x01,
+	HID_REQ_GET_IDLE		= 0x02,
+	HID_REQ_GET_PROTOCOL		= 0x03,
+	HID_REQ_SET_REPORT		= 0x09,
+	HID_REQ_SET_IDLE		= 0x0A,
+	HID_REQ_SET_PROTOCOL		= 0x0B,
+};
+
+enum hid_bpf_attach_flags {
+	HID_BPF_FLAG_NONE = 0,
+	HID_BPF_FLAG_INSERT_HEAD = _BITUL(0),
+	HID_BPF_FLAG_MAX,
+};
+
 /* following are kfuncs exported by HID for HID-BPF */
 extern __u8 *hid_bpf_get_data(struct hid_bpf_ctx *ctx,
 			      unsigned int offset,


### PR DESCRIPTION
The following error occurred when building the tests for kselftest.
```
$ make headers
$ make -C tools/testing/selftests -j$(nproc)
...
gcc -O2 -W -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wbad-function-cast -Wdeclaration-after-statement -Wformat-security -Wformat-y2k -Winit-self -Wmissing-declarations -Wmissing-prototypes -Wno-system-headers -Wold-style-definition -Wpacked -Wredundant-decls -Wstrict-prototypes -Wswitch-default -Wundef -Wwrite-strings -Wformat -Wno-type-limits -Wstrict-aliasing=3 -Wshadow -DPACKAGE='"bpftool"' -D__EXPORTED_HEADERS__ -I/disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/ -I/disk/rvck-olk/tools/testing/selftests/hid/tools/include -I/disk/rvck-olk/kernel/bpf/ -I/disk/rvck-olk/tools/include -I/disk/rvck-olk/tools/include/uapi -g -O0 -DUSE_LIBCAP -DHAVE_LIBBFD_SUPPORT -DDISASM_FOUR_ARGS_SIGNATURE -DDISASM_INIT_STYLED   /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/btf.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/btf_dumper.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/cfg.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/cgroup.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/common.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/feature.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/gen.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/iter.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/jit_disasm.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/json_writer.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/link.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/main.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/map.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/map_perf_ring.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/net.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/netlink_dumper.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/perf.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/pids.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/prog.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/struct_ops.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/tracelog.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/xlated_dumper.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/disasm.o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/libbpf/libbpf.a -lelf -lz -lcap -lbfd -ldl -lopcodes -o /disk/rvck-olk/tools/testing/selftests/hid/tools/build/bpftool/bpftool
  GEN      vmlinux.h
  CLNG-BPF hid.bpf.o
In file included from progs/hid.c:6:
progs/hid_bpf_helpers.h:9:38: error: declaration of 'struct hid_bpf_ctx' will not be visible outside of this function [-Werror,-Wvisibility]
    9 | extern __u8 *hid_bpf_get_data(struct hid_bpf_ctx *ctx,
      |                                      ^
progs/hid.c:23:35: error: incompatible pointer types passing 'struct hid_bpf_ctx *' to parameter of type 'struct hid_bpf_ctx *' [-Werror,-Wincompatible-pointer-types]
   23 |         __u8 *rw_data = hid_bpf_get_data(hid_ctx, 0 /* offset */, 3 /* size */);
      |                                          ^~~~~~~
progs/hid_bpf_helpers.h:9:51: note: passing argument to parameter 'ctx' here
    9 | extern __u8 *hid_bpf_get_data(struct hid_bpf_ctx *ctx,
      |                                                   ^
progs/hid.c:32:16: error: incomplete definition of type 'struct hid_bpf_ctx'
   32 |         return hid_ctx->size;
      |                ~~~~~~~^
progs/hid_bpf_helpers.h:13:15: note: forward declaration of 'struct hid_bpf_ctx'
   13 | extern struct hid_bpf_ctx *hid_bpf_allocate_context(unsigned int hid_id) __ksym;
      |               ^
progs/hid.c:38:35: error: incompatible pointer types passing 'struct hid_bpf_ctx *' to parameter of type 'struct hid_bpf_ctx *' [-Werror,-Wincompatible-pointer-types]
   38 |         __u8 *rw_data = hid_bpf_get_data(hid_ctx, 0 /* offset */, 4 /* size */);
      |                                          ^~~~~~~
progs/hid_bpf_helpers.h:9:51: note: passing argument to parameter 'ctx' here
    9 | extern __u8 *hid_bpf_get_data(struct hid_bpf_ctx *ctx,
      |                                                   ^
progs/hid.c:45:16: error: incomplete definition of type 'struct hid_bpf_ctx'
   45 |         return hid_ctx->size;
      |                ~~~~~~~^
progs/hid_bpf_helpers.h:13:15: note: forward declaration of 'struct hid_bpf_ctx'
   13 | extern struct hid_bpf_ctx *hid_bpf_allocate_context(unsigned int hid_id) __ksym;
      |               ^
progs/hid.c:51:35: error: incompatible pointer types passing 'struct hid_bpf_ctx *' to parameter of type 'struct hid_bpf_ctx *' [-Werror,-Wincompatible-pointer-types]
   51 |         __u8 *rw_data = hid_bpf_get_data(hid_ctx, 0 /* offset */, 3 /* size */);
      |                                          ^~~~~~~
progs/hid_bpf_helpers.h:9:51: note: passing argument to parameter 'ctx' here
    9 | extern __u8 *hid_bpf_get_data(struct hid_bpf_ctx *ctx,
      |                                                   ^
progs/hid.c:66:27: error: use of undeclared identifier 'HID_BPF_FLAG_INSERT_HEAD'
   66 |                                           ctx->insert_head ? HID_BPF_FLAG_INSERT_HEAD :
      |                                                              ^
progs/hid.c:67:13: error: use of undeclared identifier 'HID_BPF_FLAG_NONE'
   67 |                                                              HID_BPF_FLAG_NONE);
      |                                                              ^
progs/hid.c:144:32: error: incompatible pointer types passing 'struct hid_bpf_ctx *' to parameter of type 'struct hid_bpf_ctx *' [-Werror,-Wincompatible-pointer-types]
  144 |         __u8 *data = hid_bpf_get_data(hid_ctx, 0 /* offset */, 4096 /* size */);
      |                                       ^~~~~~~
progs/hid_bpf_helpers.h:9:51: note: passing argument to parameter 'ctx' here
    9 | extern __u8 *hid_bpf_get_data(struct hid_bpf_ctx *ctx,
      |                                                   ^
progs/hid.c:163:32: error: incompatible pointer types passing 'struct hid_bpf_ctx *' to parameter of type 'struct hid_bpf_ctx *' [-Werror,-Wincompatible-pointer-types]
  163 |         __u8 *data = hid_bpf_get_data(hid_ctx, 0 /* offset */, 4 /* size */);
      |                                       ^~~~~~~
progs/hid_bpf_helpers.h:9:51: note: passing argument to parameter 'ctx' here
    9 | extern __u8 *hid_bpf_get_data(struct hid_bpf_ctx *ctx,
      |                                                   ^
progs/hid.c:180:32: error: incompatible pointer types passing 'struct hid_bpf_ctx *' to parameter of type 'struct hid_bpf_ctx *' [-Werror,-Wincompatible-pointer-types]
  180 |         __u8 *data = hid_bpf_get_data(hid_ctx, 0 /* offset */, 4 /* size */);
      |                                       ^~~~~~~
progs/hid_bpf_helpers.h:9:51: note: passing argument to parameter 'ctx' here
    9 | extern __u8 *hid_bpf_get_data(struct hid_bpf_ctx *ctx,
      |                                                   ^
progs/hid.c:197:32: error: incompatible pointer types passing 'struct hid_bpf_ctx *' to parameter of type 'struct hid_bpf_ctx *' [-Werror,-Wincompatible-pointer-types]
  197 |         __u8 *data = hid_bpf_get_data(hid_ctx, 0 /* offset */, 4 /* size */);
      |                                       ^~~~~~~
progs/hid_bpf_helpers.h:9:51: note: passing argument to parameter 'ctx' here
    9 | extern __u8 *hid_bpf_get_data(struct hid_bpf_ctx *ctx,
      |                                                   ^
12 errors generated.
make[1]: *** [Makefile:230: /disk/rvck-olk/tools/testing/selftests/hid/hid.bpf.o] Error 1
make[1]: Leaving directory '/disk/rvck-olk/tools/testing/selftests/hid'
```
Link: <https://lore.kernel.org/all/20230825-wip-selftests-v3-1-639963c54109@kernel.org/>