### PR TITLE
sync: rvck93: xuantie: nna: select SYNC_FILE

### DIFF
--- a/drivers/soc/xuantie/nna/Kconfig
+++ b/drivers/soc/xuantie/nna/Kconfig
@@ -1,6 +1,7 @@
 menuconfig VHA
        tristate "IMG neural network accelerator"
        default n
+       select SYNC_FILE
 
 if VHA
 choice 


### PR DESCRIPTION
riscv inclusion
category: bugfix
bugzilla: https://github.com/ruyisdk/linux-xuantie-kernel/issues/214 CVE: NA

--------------------------------

Make VHA select SYNC_FILE to avoid KUnit test errors:

    ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `.L0 ':
    vha_common.c:(.text+0x4da): undefined reference to `dma_fence_release'
    ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `dma_fence_put.part.0':
    vha_common.c:(.text+0x52e): undefined reference to `dma_fence_release'
    ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `_vha_in_merged_sync_cb':
    vha_common.c:(.text+0x58c): undefined reference to `dma_fence_release'
    ...
    ld: vha_common.c:(.text+0x2cbe): undefined reference to `sync_file_create'
    ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `.L774':
    vha_common.c:(.text+0x2ce8): undefined reference to `dma_fence_add_callback'
    ld: drivers/soc/xuantie/nna/vha/vha_common.o: in function `vha_buf_needs_inval':
    vha_common.c:(.text+0x2ec6): undefined reference to `sync_file_get_fence'
    ld: vha_common.c:(.text+0x2ee6): undefined reference to `dma_fence_add_callback'
    ld: vha_common.c:(.text+0x2f2e): undefined reference to `dma_fence_context_alloc'
    ld: vha_common.c:(.text+0x2f40): undefined reference to `dma_fence_array_create'
    ld: vha_common.c:(.text+0x2f52): undefined reference to `sync_file_create'


Sync from rvck.
Link: https://github.com/RVCK-Project/rvck/pull/93