### PR TITLE
sync: rvck82: backport iommu关于default_domain的改动

### DIFF
--- a/drivers/iommu/iommu.c
+++ b/drivers/iommu/iommu.c
@@ -3369,6 +3369,11 @@ int iommu_device_use_default_domain(struct device *dev)
 		return 0;
 
 	mutex_lock(&group->mutex);
+	/* We may race against bus_iommu_probe() finalising groups here */
+	if (!group->default_domain) {
+		ret = -EPROBE_DEFER;
+		goto unlock_out;
+	}
 	if (group->owner_cnt) {
 		if (group->owner || !iommu_is_default_domain(group) ||
 		    !xa_empty(&group->pasid_array)) {

--- a/drivers/soc/xuantie/nna/Kconfig
+++ b/drivers/soc/xuantie/nna/Kconfig
@@ -1,6 +1,7 @@
 menuconfig VHA
        tristate "IMG neural network accelerator"
        default n
+       select SYNC_FILE
 
 if VHA
 choice 


### PR DESCRIPTION
Sync from rvck.
Link: https://github.com/RVCK-Project/rvck/pull/82

已过滤 OLK-6.6 已回合的主线补丁