### PR TITLE
Enable gade when iommu has AMO_HWAD cap

### DIFF
--- a/drivers/iommu/riscv/iommu.c
+++ b/drivers/iommu/riscv/iommu.c
@@ -1564,7 +1564,7 @@ static struct iommu_device *riscv_iommu_probe_device(struct device *dev)
 	 */
 	tc = 0;
 	if (iommu->caps & RISCV_IOMMU_CAPABILITIES_AMO_HWAD)
-		tc |= RISCV_IOMMU_DC_TC_SADE;
+		tc |= RISCV_IOMMU_DC_TC_SADE | RISCV_IOMMU_DC_TC_GADE;
 	for (i = 0; i < fwspec->num_ids; i++) {
 		dc = riscv_iommu_get_dc(iommu, fwspec->ids[i]);
 		if (!dc) {


### PR DESCRIPTION
Enable gade when iommu has AMO_HWAD cap

driver inclusion
category: bugfix
bugzilla: https://github.com/RVCK-Project/rvck-olk/issues/145

---------------------------------

If GADE (Guest Atomic D-bit and A-bit Update Enable) is set to 1,
the IOMMU will atomically update the Accessed (A) and Dirty (D)
bits in second-stage page table entries (PTEs). If GADE is set to 0,
the IOMMU will trigger a guest-page-fault corresponding to the
original access type under either of the following conditions: when
the A bit is 0, or when the memory access is a store operation and
the D bit is 0. The driver must enable GADE when the IOMMU has the
AMO_HWAD (Atomic Memory Operation for Hardware A/D bits) capability.

Signed-off-by: jinqi <jin.qi@zte.com.cn>
Signed-off-by: liuqingtao <liu.qingtao2@zte.com.cn>