### PR TITLE
sync: rvck #138: riscv: drm: img-rogue: Convert structure initializations to designated initializers

### DIFF
--- a/drivers/gpu/drm/img-rogue/physmem_hostmem.c
+++ b/drivers/gpu/drm/img-rogue/physmem_hostmem.c
@@ -66,9 +66,9 @@ static void HostMemDevPAddrToCpuPAddr(IMG_HANDLE hPrivData,
 static PHYS_HEAP_FUNCTIONS gsHostMemDevPhysHeapFuncs =
 {
 	/* pfnCpuPAddrToDevPAddr */
-	HostMemCpuPAddrToDevPAddr,
+	.pfnCpuPAddrToDevPAddr = HostMemCpuPAddrToDevPAddr,
 	/* pfnDevPAddrToCpuPAddr */
-	HostMemDevPAddrToCpuPAddr,
+	.pfnDevPAddrToCpuPAddr = HostMemDevPAddrToCpuPAddr
 };
 
 static PVRSRV_DEVICE_CONFIG gsHostMemDevConfig[];

--- a/drivers/gpu/drm/img-rogue/physmem_lma.c
+++ b/drivers/gpu/drm/img-rogue/physmem_lma.c
@@ -1843,31 +1843,31 @@ PVRSRV_ERROR PMRChangeSparseMemCPUMapLocalMem(PMR_IMPL_PRIVDATA pPriv,
 
 static PMR_IMPL_FUNCTAB _sPMRLMAFuncTab = {
 	/* pfnLockPhysAddresses */
-	&PMRLockSysPhysAddressesLocalMem,
+	.pfnLockPhysAddresses = &PMRLockSysPhysAddressesLocalMem,
 	/* pfnUnlockPhysAddresses */
-	&PMRUnlockSysPhysAddressesLocalMem,
+	.pfnUnlockPhysAddresses = &PMRUnlockSysPhysAddressesLocalMem,
 	/* pfnDevPhysAddr */
-	&PMRSysPhysAddrLocalMem,
+	.pfnDevPhysAddr = &PMRSysPhysAddrLocalMem,
 	/* pfnAcquireKernelMappingData */
-	&PMRAcquireKernelMappingDataLocalMem,
+	.pfnAcquireKernelMappingData = &PMRAcquireKernelMappingDataLocalMem,
 	/* pfnReleaseKernelMappingData */
-	&PMRReleaseKernelMappingDataLocalMem,
+	.pfnReleaseKernelMappingData = &PMRReleaseKernelMappingDataLocalMem,
 	/* pfnReadBytes */
-	&PMRReadBytesLocalMem,
+	.pfnReadBytes = &PMRReadBytesLocalMem,
 	/* pfnWriteBytes */
-	&PMRWriteBytesLocalMem,
+	.pfnWriteBytes = &PMRWriteBytesLocalMem,
 	/* pfnUnpinMem */
-	NULL,
+	.pfnUnpinMem = NULL,
 	/* pfnPinMem */
-	NULL,
+	.pfnPinMem = NULL,
 	/* pfnChangeSparseMem*/
-	&PMRChangeSparseMemLocalMem,
+	.pfnChangeSparseMem = &PMRChangeSparseMemLocalMem,
 	/* pfnChangeSparseMemCPUMap */
-	&PMRChangeSparseMemCPUMapLocalMem,
+	.pfnChangeSparseMemCPUMap = &PMRChangeSparseMemCPUMapLocalMem,
 	/* pfnMMap */
-	NULL,
+	.pfnMMap = NULL,
 	/* pfnFinalize */
-	&PMRFinalizeLocalMem
+	.pfnFinalize = &PMRFinalizeLocalMem
 };
 
 PVRSRV_ERROR

--- a/drivers/gpu/drm/img-rogue/sysconfig.c
+++ b/drivers/gpu/drm/img-rogue/sysconfig.c
@@ -151,9 +151,9 @@ void UMAPhysHeapDevPAddrToCpuPAddr(IMG_HANDLE hPrivData,
 static PHYS_HEAP_FUNCTIONS gsPhysHeapFuncs =
 {
 	/* pfnCpuPAddrToDevPAddr */
-	UMAPhysHeapCpuPAddrToDevPAddr,
+	.pfnCpuPAddrToDevPAddr = UMAPhysHeapCpuPAddrToDevPAddr,
 	/* pfnDevPAddrToCpuPAddr */
-	UMAPhysHeapDevPAddrToCpuPAddr,
+	.pfnDevPAddrToCpuPAddr = UMAPhysHeapDevPAddrToCpuPAddr,
 };
 
 static PVRSRV_ERROR PhysHeapsCreate(PHYS_HEAP_CONFIG **ppasPhysHeapsOut,

--- a/drivers/gpu/drm/img-rogue/vmm_type_stub.c
+++ b/drivers/gpu/drm/img-rogue/vmm_type_stub.c
@@ -75,29 +75,29 @@ static VMM_PVZ_CONNECTION gsStubVmmPvz =
 {
 	.sClientFuncTab = {
 		/* pfnMapDevPhysHeap */
-		&StubVMMMapDevPhysHeap,
+		.pfnMapDevPhysHeap = &StubVMMMapDevPhysHeap,
 
 		/* pfnUnmapDevPhysHeap */
-		&StubVMMUnmapDevPhysHeap
+		.pfnUnmapDevPhysHeap = &StubVMMUnmapDevPhysHeap
 	},
 
 	.sServerFuncTab = {
 		/* pfnMapDevPhysHeap */
-		&PvzServerMapDevPhysHeap,
+		.pfnMapDevPhysHeap = &PvzServerMapDevPhysHeap,
 
 		/* pfnUnmapDevPhysHeap */
-		&PvzServerUnmapDevPhysHeap
+		.pfnUnmapDevPhysHeap = &PvzServerUnmapDevPhysHeap
 	},
 
 	.sVmmFuncTab = {
 		/* pfnOnVmOnline */
-		&PvzServerOnVmOnline,
+		.pfnOnVmOnline = &PvzServerOnVmOnline,
 
 		/* pfnOnVmOffline */
-		&PvzServerOnVmOffline,
+		.pfnOnVmOffline = &PvzServerOnVmOffline,
 
 		/* pfnVMMConfigure */
-		&PvzServerVMMConfigure
+		.pfnVMMConfigure = &PvzServerVMMConfigure
 	}
 };
 


### PR DESCRIPTION
Sync commits from rvck PR #138.

Source PR: https://github.com/RVCK-Project/rvck/pull/138

### Commits

- `b3057db65dbf` riscv: drm: img-rogue: Convert structure initializations to designated initializers
