### PR TITLE
sync: rvck #170: Revert "mm: Modify __find_max_addr for memory hole"

### DIFF
--- a/mm/memblock.c
+++ b/mm/memblock.c
@@ -1811,7 +1811,6 @@ phys_addr_t __init_memblock memblock_end_of_DRAM(void)
 
 static phys_addr_t __init_memblock __find_max_addr(phys_addr_t limit)
 {
-	phys_addr_t phys_ram_base = memblock_start_of_DRAM();
 	phys_addr_t max_addr = PHYS_ADDR_MAX;
 	struct memblock_region *r;
 
@@ -1821,10 +1820,11 @@ static phys_addr_t __init_memblock __find_max_addr(phys_addr_t limit)
 	 * of those regions, max_addr will keep original value PHYS_ADDR_MAX
 	 */
 	for_each_mem_region(r) {
-		if ((r->base + r->size) >= (phys_ram_base + limit)) {
-			max_addr = phys_ram_base + limit;
+		if (limit <= r->size) {
+			max_addr = r->base + limit;
 			break;
 		}
+		limit -= r->size;
 	}
 
 	return max_addr;


### PR DESCRIPTION
Sync commits from rvck PR #170.

Source PR: https://github.com/RVCK-Project/rvck/pull/170

### Commits

- `bec2630c5fb2` Revert "sg2042: mm: Modify __find_max_addr for memory hole"
