### PR TITLE
sync: rvck #169: Revert "riscv: mm: Clear compilation warning about last_cpupid"

### DIFF
--- a/arch/riscv/include/asm/sparsemem.h
+++ b/arch/riscv/include/asm/sparsemem.h
@@ -5,7 +5,7 @@
 
 #ifdef CONFIG_SPARSEMEM
 #ifdef CONFIG_64BIT
-#define MAX_PHYSMEM_BITS	44
+#define MAX_PHYSMEM_BITS	56
 #else
 #define MAX_PHYSMEM_BITS	32
 #endif /* CONFIG_64BIT */


### PR DESCRIPTION
Sync commits from rvck PR #169.

Source PR: https://github.com/RVCK-Project/rvck/pull/169

### Commits

- `4fb25f6774a3` Revert "sg2042: riscv: mm: Clear compilation warning about last_cpupid"
