### PR TITLE
sync: riscv: acpi: avoid errors caused by probing DT devices when ACPI is used

### DIFF
--- a/arch/riscv/kernel/setup.c
+++ b/arch/riscv/kernel/setup.c
@@ -353,11 +353,14 @@ void __init setup_arch(char **cmdline_p)
 	/* Parse the ACPI tables for possible boot-time configuration */
 	acpi_boot_table_init();
 
+	if (acpi_disabled) {
 #if IS_ENABLED(CONFIG_BUILTIN_DTB)
-	unflatten_and_copy_device_tree();
+		unflatten_and_copy_device_tree();
 #else
-	unflatten_device_tree();
+		unflatten_device_tree();
 #endif
+	}
+
 	misc_mem_init();
 
 	init_resources();


### PR DESCRIPTION
Sync commits (no rvck PR association).

### Commits

- `c9286d45f3ee` riscv: acpi: avoid errors caused by probing DT devices when ACPI is used
