### PR TITLE
sync: rvck #309: iommu/riscv: add dma_wmb before cmpxchg_relaxed

### DIFF
--- a/drivers/iommu/riscv/iommu.c
+++ b/drivers/iommu/riscv/iommu.c
@@ -1123,6 +1123,15 @@ pte_retry:
 				return NULL;
 			old = pte;
 			pte = _io_pte_entry(virt_to_pfn(addr), _PAGE_TABLE);
+
+			/*
+			 * To ensure that the table itself is visible prior to its PTE,
+			 * a barrier is required; additionally, the dma_wmb primitive is
+			 * selected to avoid potential race conditions between
+			 * the IOMMU and the CPU.
+			 */
+			dma_wmb();
+
 			if (cmpxchg_relaxed(ptr, old, pte) != old) {
 				iommu_free_page(addr);
 				goto pte_retry;
@@ -1186,6 +1195,15 @@ static int riscv_iommu_map_pages(struct iommu_domain *iommu_domain,
 
 		old = READ_ONCE(*ptr);
 		pte = _io_pte_entry(phys_to_pfn(phys), pte_prot);
+
+		/*
+		 * To ensure that the table itself is visible prior to its PTE,
+		 * a barrier is required; additionally, the dma_wmb primitive is
+		 * selected to avoid potential race conditions between
+		 * the IOMMU and the CPU.
+		 */
+		dma_wmb();
+
 		if (cmpxchg_relaxed(ptr, old, pte) != old)
 			continue;
 


### PR DESCRIPTION
Sync commits from rvck PR 309.
Source PR: https://github.com/RVCK-Project/rvck/pull/309